### PR TITLE
add option for Querystring: true. not sure how to test

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -56,6 +56,7 @@ function Api(_ref) {
     headers: {
       'Authorization': 'Bearer ' + token
     },
+    useQuerystring: true,
     json: true
   };
 

--- a/src/api.js
+++ b/src/api.js
@@ -36,6 +36,7 @@ export default function Api({ token }) {
     headers: {
       'Authorization': `Bearer ${token}`
     },
+    useQuerystring: true,
     json: true
   };
 

--- a/test/api.js
+++ b/test/api.js
@@ -149,5 +149,21 @@ describe('api', () => {
         api.__ResetDependency__('rp');
       });
     });
+
+    it('should encode arrays using querystring', () => {
+      const token = 'testToken';
+      const qs = { pets: ['cat', 'dog'] };
+
+      api.__Rewire__('rp', (opts) => {
+        expect(opts.qs).to.equal(qs);
+        expect(opts.useQuerystring).to.equal(true);
+        return Promise.resolve();
+      });
+
+      api({ token }).get('/test', { qs })
+      .then(() => {
+        api.__ResetDependency__('rp');
+      });
+    });
   });
 });


### PR DESCRIPTION
We use `template=test&template=test2` while request (and request-promise) default to `template[0]=test&template[1]=test2`
