### PR TITLE
[LYNX-90] enable working example with download

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -13,8 +13,7 @@ client.audits.findAll({ since: '2016-01-01' })
   const audit = audits[0];
   client.exports.create({ auditId: audit.audit_id }).then((auditExport) => {
     client.exports.get({ auditId: audit.audit_id, id: auditExport.id }).then((response) => {
-      client.exports.download({ uri: response.href, dir: '.' })
-      .catch((error) => console.log(error));
+      client.exports.download({ uri: response.href, dir: '.' });
     });
   });
 })

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,16 +1,21 @@
 import { Client } from '../lib/index';
-import _ from 'lodash';
 
 const TOKEN = process.env.SAFETYCULTURE_TOKEN;
-const client = Client({token: TOKEN, logger: console});
 
-client.audits.findAll({since: '2016-01-01'})
-             .then((audits) => {
-               audits.forEach((audit) => {
-                client.exports.create({ auditId: audit.audit_id }).then((auditExport) => {
-                  client.exports.get({auditId: audit.audit_id, id: auditExport.id }).then((response) => {
-                    console.log(response.href);
-                  });
-                })
-               });
-             });
+// apiUrl is optional and will default to the production API URL
+const URL = process.env.SAFETYCULTURE_URL;
+
+const client = Client({ token: TOKEN, logger: console, apiUrl: URL });
+
+client.audits.findAll({ since: '2016-01-01' })
+.then((audits) => {
+  // export and download the first audit found
+  const audit = audits[0];
+  client.exports.create({ auditId: audit.audit_id }).then((auditExport) => {
+    client.exports.get({ auditId: audit.audit_id, id: auditExport.id }).then((response) => {
+      client.exports.download({ uri: response.href, dir: '.' })
+      .catch((error) => console.log(error));
+    });
+  });
+})
+.catch((error) => console.log(error.error.message));

--- a/examples/oldschool.js
+++ b/examples/oldschool.js
@@ -1,0 +1,5 @@
+var SafetyCulture = require('../lib/index');
+console.log(SafetyCulture);
+
+var Client = SafetyCulture.Client;
+

--- a/examples/password.js
+++ b/examples/password.js
@@ -1,0 +1,11 @@
+import { generateToken } from '../lib/index';
+
+const USERNAME = process.env.SAFETYCULTURE_USERNAME;
+const PASSWORD = process.env.SAFETYCULTURE_PASSWORD;
+
+// apiUrl is optional and will default to the production API URL
+const URL = process.env.SAFETYCULTURE_URL;
+
+generateToken(USERNAME, PASSWORD).then((response) => {
+  console.log(response);
+});

--- a/lib/api.js
+++ b/lib/api.js
@@ -68,19 +68,14 @@ function Api(_ref) {
     json: true
   };
 
-  var getUri = function getUri(_ref2) {
-    var uri = _ref2.uri;
-    var options = _ref2.options;
-    var toStream = _ref2.toStream;
-
-    var params = _lodash2.default.assign({}, defaultOptions, { uri: uri }, options);
-    if (toStream) return (0, _request2.default)(params).pipe(toStream);
-    return (0, _requestPromise2.default)(_lodash2.default.assign({}, defaultOptions, { uri: uri }, options));
+  var build = function build(uri, options) {
+    return _lodash2.default.assign({}, defaultOptions, { uri: uri }, options);
   };
 
   return {
     /**
     * Posts body to endpoint on SafetyCulture
+    *
     * @param {string} endpoint        The endpoint to post to on SafetyCulture
     * @param {object} [args.options]  Request options
     * @returns {Promise} Resolves to body of response,
@@ -97,27 +92,34 @@ function Api(_ref) {
 
     /**
     * Gets from endpoint on SafetyCulture
+    *
     * @param {string} endpoint         The endpoint to get from on SafetyCulture
     * @param {object} [args.options]   Request options
-    * @param {stream} [args.toStream]  A file stream to write response body to
     * @returns {Promise} Unless write stream is specified.
     *                    Resolves to body of response,
     *                    Rejects with an error from API.
     */
-    get: function get(endpoint, options, toStream) {
-      return getUri({ uri: apiUrl + endpoint, options: options, toStream: toStream });
+    get: function get(endpoint, options) {
+      return (0, _requestPromise2.default)(build(apiUrl + endpoint, options));
     },
 
 
     /**
-    * Gets from URI
-    * @param {string} args.uri         The URI to get from
+    * GET output to Stream
+    *
+    * @param {string} uri         The URI to get from
     * @param {object} [args.options]   Request options
-    * @param {stream} [args.toStream]  A file stream to write response body to
+    * @param {stream} [args.stream]  A file stream to write response body to
     * @returns {Promise} Unless write stream is specified.
     *                    Resolves to body of response,
     *                    Rejects with an error from API.
     */
-    getUri: getUri
+    streamGet: function streamGet(uri, _ref2) {
+      var _ref2$options = _ref2.options;
+      var options = _ref2$options === undefined ? {} : _ref2$options;
+      var stream = _ref2.stream;
+
+      return (0, _request2.default)(build(uri, options)).pipe(stream);
+    }
   };
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -11,6 +11,10 @@ var _requestPromise = require('request-promise');
 
 var _requestPromise2 = _interopRequireDefault(_requestPromise);
 
+var _request = require('request');
+
+var _request2 = _interopRequireDefault(_request);
+
 var _lodash = require('lodash');
 
 var _lodash2 = _interopRequireDefault(_lodash);
@@ -64,14 +68,25 @@ function Api(_ref) {
     json: true
   };
 
+  var getUri = function getUri(_ref2) {
+    var uri = _ref2.uri;
+    var options = _ref2.options;
+    var toStream = _ref2.toStream;
+
+    var params = _lodash2.default.assign({}, defaultOptions, { uri: uri }, options);
+    if (toStream) return (0, _request2.default)(params).pipe(toStream);
+    return (0, _requestPromise2.default)(_lodash2.default.assign({}, defaultOptions, { uri: uri }, options));
+  };
+
   return {
     /**
     * Posts body to endpoint on SafetyCulture
-    * @param {string} endpoint The endpoint to post to on SafetyCulture
-    * @param {object} body The body to post
+    * @param {string} endpoint        The endpoint to post to on SafetyCulture
+    * @param {object} [args.options]  Request options
     * @returns {Promise} Resolves to body of response,
     *                    Rejects with an error from API.
     */
+
     post: function post(endpoint, options) {
       return (0, _requestPromise2.default)(_lodash2.default.assign({}, defaultOptions, {
         method: 'POST',
@@ -79,16 +94,30 @@ function Api(_ref) {
       }, options));
     },
 
+
     /**
     * Gets from endpoint on SafetyCulture
-    * @param {string} endpoint The endpoint to get from on SafetyCulture
-    * @returns {Promise} Resolves to body of response,
+    * @param {string} endpoint         The endpoint to get from on SafetyCulture
+    * @param {object} [args.options]   Request options
+    * @param {stream} [args.toStream]  A file stream to write response body to
+    * @returns {Promise} Unless write stream is specified.
+    *                    Resolves to body of response,
     *                    Rejects with an error from API.
     */
-    get: function get(endpoint, options) {
-      return (0, _requestPromise2.default)(_lodash2.default.assign({}, defaultOptions, {
-        uri: apiUrl + endpoint
-      }, options));
-    }
+    get: function get(endpoint, options, toStream) {
+      return getUri({ uri: apiUrl + endpoint, options: options, toStream: toStream });
+    },
+
+
+    /**
+    * Gets from URI
+    * @param {string} args.uri         The URI to get from
+    * @param {object} [args.options]   Request options
+    * @param {stream} [args.toStream]  A file stream to write response body to
+    * @returns {Promise} Unless write stream is specified.
+    *                    Resolves to body of response,
+    *                    Rejects with an error from API.
+    */
+    getUri: getUri
   };
 }

--- a/lib/audits.js
+++ b/lib/audits.js
@@ -60,3 +60,4 @@ function Audits(api, logger) {
     }
   };
 }
+module.exports = exports['default'];

--- a/lib/audits.js
+++ b/lib/audits.js
@@ -60,4 +60,3 @@ function Audits(api, logger) {
     }
   };
 }
-module.exports = exports['default'];

--- a/lib/client.js
+++ b/lib/client.js
@@ -45,4 +45,3 @@ function Client(_ref) {
     audits: (0, _audits2.default)(api, logger)
   };
 }
-module.exports = exports['default'];

--- a/lib/client.js
+++ b/lib/client.js
@@ -21,6 +21,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var DEFAULT_LOGGER = { info: function info() {},
   error: function error() {} };
+
 /**
 * Generates Client methods based off passed in token
 *
@@ -45,3 +46,4 @@ function Client(_ref) {
     audits: (0, _audits2.default)(api, logger)
   };
 }
+module.exports = exports['default'];

--- a/lib/exports.js
+++ b/lib/exports.js
@@ -119,9 +119,9 @@ function Exports(api, logger) {
       var dir = _ref4$dir === undefined ? '.' : _ref4$dir;
       var filename = _ref4.filename;
 
-      var targetFilename = filename || uri.match(/\/([^/]+)$/)[1];
+      var targetFilename = decodeURIComponent(filename || uri.match(/\/([^/]+)$/)[1]);
       logger.info('Downloading export\n   from ' + uri + '\n   to ' + dir + '/' + targetFilename);
-      return api.getUri({ uri: uri, toStream: _fs2.default.createWriteStream(dir + '/' + targetFilename) });
+      return api.streamGet(uri, { stream: _fs2.default.createWriteStream(dir + '/' + targetFilename) });
     }
   };
 }

--- a/lib/exports.js
+++ b/lib/exports.js
@@ -10,6 +10,10 @@ var _bluebird = require('bluebird');
 
 var _bluebird2 = _interopRequireDefault(_bluebird);
 
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var DEFAULT_TIMEZONE = exports.DEFAULT_TIMEZONE = 'UTC';
@@ -35,6 +39,7 @@ function Exports(api, logger) {
     * @returns {Promise} Resolves to successfully created export,
     *                    Rejects with an error from API.
     */
+
     create: function create(_ref) {
       var auditId = _ref.auditId;
       var _ref$timezone = _ref.timezone;
@@ -45,6 +50,7 @@ function Exports(api, logger) {
       logger.info('Creating export for ' + auditId + ' (' + timezone + ', ' + format + ')');
       return api.post('/audits/' + auditId + '/export', { qs: { format: format, timezone: timezone } });
     },
+
 
     /**
     * Find a promise by audit id and id
@@ -60,6 +66,7 @@ function Exports(api, logger) {
 
       return api.get('/audits/' + auditId + '/exports/' + id);
     },
+
 
     /**
     * Get an export (poll until completed)
@@ -96,6 +103,25 @@ function Exports(api, logger) {
       };
 
       return attempt();
+    },
+
+
+    /**
+    * Download an export
+    *
+    * @param {string} uri Export uri
+    * @param {string} [dir=.] Directory to save to
+    * @returns {Promise} Rejects with an error from API.
+    */
+    download: function download(_ref4) {
+      var uri = _ref4.uri;
+      var _ref4$dir = _ref4.dir;
+      var dir = _ref4$dir === undefined ? '.' : _ref4$dir;
+      var filename = _ref4.filename;
+
+      var targetFilename = filename || uri.match(/\/([^/]+)$/)[1];
+      logger.info('Downloading export\n   from ' + uri + '\n   to ' + dir + '/' + targetFilename);
+      return api.getUri({ uri: uri, toStream: _fs2.default.createWriteStream(dir + '/' + targetFilename) });
     }
   };
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,12 +3,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.Client = undefined;
+exports.generateToken = exports.Client = undefined;
 
 var _client = require('./client');
 
 var _client2 = _interopRequireDefault(_client);
 
+var _api = require('./api');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.Client = _client2.default;
+exports.generateToken = _api.generateToken;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.Client = undefined;
 
 var _client = require('./client');
 
@@ -10,7 +11,4 @@ var _client2 = _interopRequireDefault(_client);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.default = {
-  Client: _client2.default
-};
-module.exports = exports['default'];
+exports.Client = _client2.default;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "npm run lint && BABEL_ENV=TEST mocha --compilers js:babel-core/register",
     "compile": "babel --presets es2015 -d lib/ src/",
     "distribute": "npm run prepublish && webpack -p",
-    "prepublish": "npm run compile"
+    "prepublish": "npm run compile",
+    "example:export": "babel-node  --presets es2015 ./examples/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/api.js
+++ b/src/api.js
@@ -41,15 +41,14 @@ export default function Api({ token, apiUrl = BASE_URL }) {
     json: true
   };
 
-  const getUri = ({ uri, options, toStream }) => {
-    const params = _.assign({}, defaultOptions, { uri }, options);
-    if (toStream) return request(params).pipe(toStream);
-    return rp(_.assign({}, defaultOptions, { uri }, options));
+  const build = (uri, options) => {
+    return _.assign({}, defaultOptions, { uri }, options);
   };
 
   return {
     /**
     * Posts body to endpoint on SafetyCulture
+    *
     * @param {string} endpoint        The endpoint to post to on SafetyCulture
     * @param {object} [args.options]  Request options
     * @returns {Promise} Resolves to body of response,
@@ -64,26 +63,29 @@ export default function Api({ token, apiUrl = BASE_URL }) {
 
     /**
     * Gets from endpoint on SafetyCulture
+    *
     * @param {string} endpoint         The endpoint to get from on SafetyCulture
     * @param {object} [args.options]   Request options
-    * @param {stream} [args.toStream]  A file stream to write response body to
     * @returns {Promise} Unless write stream is specified.
     *                    Resolves to body of response,
     *                    Rejects with an error from API.
     */
-    get(endpoint, options, toStream) {
-      return getUri({ uri: apiUrl + endpoint, options, toStream });
+    get(endpoint, options) {
+      return rp(build(apiUrl + endpoint, options));
     },
 
     /**
-    * Gets from URI
-    * @param {string} args.uri         The URI to get from
+    * GET output to Stream
+    *
+    * @param {string} uri         The URI to get from
     * @param {object} [args.options]   Request options
-    * @param {stream} [args.toStream]  A file stream to write response body to
+    * @param {stream} [args.stream]  A file stream to write response body to
     * @returns {Promise} Unless write stream is specified.
     *                    Resolves to body of response,
     *                    Rejects with an error from API.
     */
-    getUri
+    streamGet(uri, { options = {}, stream }) {
+      return request(build(uri, options)).pipe(stream);
+    }
   };
 }

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,5 @@
 import rp from 'request-promise';
+import request from 'request';
 import _ from 'lodash';
 
 export const BASE_URL = 'https://api.safetyculture.io';
@@ -40,27 +41,49 @@ export default function Api({ token, apiUrl = BASE_URL }) {
     json: true
   };
 
+  const getUri = ({ uri, options, toStream }) => {
+    const params = _.assign({}, defaultOptions, { uri }, options);
+    if (toStream) return request(params).pipe(toStream);
+    return rp(_.assign({}, defaultOptions, { uri }, options));
+  };
+
   return {
     /**
     * Posts body to endpoint on SafetyCulture
-    * @param {string} endpoint The endpoint to post to on SafetyCulture
-    * @param {object} body The body to post
+    * @param {string} endpoint        The endpoint to post to on SafetyCulture
+    * @param {object} [args.options]  Request options
     * @returns {Promise} Resolves to body of response,
     *                    Rejects with an error from API.
     */
-    post: (endpoint, options) => rp(_.assign({}, defaultOptions, {
-      method: 'POST',
-      uri: apiUrl + endpoint
-    }, options)),
+    post(endpoint, options) {
+      return rp(_.assign({}, defaultOptions, {
+        method: 'POST',
+        uri: apiUrl + endpoint
+      }, options));
+    },
 
     /**
     * Gets from endpoint on SafetyCulture
-    * @param {string} endpoint The endpoint to get from on SafetyCulture
-    * @returns {Promise} Resolves to body of response,
+    * @param {string} endpoint         The endpoint to get from on SafetyCulture
+    * @param {object} [args.options]   Request options
+    * @param {stream} [args.toStream]  A file stream to write response body to
+    * @returns {Promise} Unless write stream is specified.
+    *                    Resolves to body of response,
     *                    Rejects with an error from API.
     */
-    get: (endpoint, options) => rp(_.assign({}, defaultOptions, {
-      uri: apiUrl + endpoint
-    }, options))
+    get(endpoint, options, toStream) {
+      return getUri({ uri: apiUrl + endpoint, options, toStream });
+    },
+
+    /**
+    * Gets from URI
+    * @param {string} args.uri         The URI to get from
+    * @param {object} [args.options]   Request options
+    * @param {stream} [args.toStream]  A file stream to write response body to
+    * @returns {Promise} Unless write stream is specified.
+    *                    Resolves to body of response,
+    *                    Rejects with an error from API.
+    */
+    getUri
   };
 }

--- a/src/client.js
+++ b/src/client.js
@@ -4,6 +4,7 @@ import Exports from './exports';
 
 const DEFAULT_LOGGER = {info: () => {},
                         error: () => {}};
+
 /**
 * Generates Client methods based off passed in token
 *

--- a/src/exports.js
+++ b/src/exports.js
@@ -49,7 +49,7 @@ export default function Exports(api, logger) {
     * @returns {Promise} Resolves to requested export,
     *                    Rejects with an error from API.
     */
-    get({ auditId, id, poll = POLL_TIME, tries = MAX_TRIES}) {
+    get({ auditId, id, poll = POLL_TIME, tries = MAX_TRIES }) {
       let attempts = 1;
 
       let attempt = () => {
@@ -77,9 +77,9 @@ export default function Exports(api, logger) {
     * @returns {Promise} Rejects with an error from API.
     */
     download({ uri, dir = '.', filename }) {
-      const targetFilename = filename || uri.match(/\/([^/]+)$/)[1];
+      const targetFilename = decodeURIComponent(filename || uri.match(/\/([^/]+)$/)[1]);
       logger.info(`Downloading export\n   from ${uri}\n   to ${dir}/${targetFilename}`);
-      return api.getUri({ uri, toStream: fs.createWriteStream(`${dir}/${targetFilename}`) });
+      return api.streamGet(uri, { stream: fs.createWriteStream(`${dir}/${targetFilename}`) });
     }
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
 import Client from './client';
 
-export default {
-  Client
-};
+export { Client };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 import Client from './client';
+import { generateToken } from './api';
 
-export { Client };
+export { Client , generateToken };

--- a/test/api.js
+++ b/test/api.js
@@ -1,5 +1,6 @@
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
+import Promise from 'bluebird';
 
 chai.use(sinonChai);
 

--- a/test/audits.js
+++ b/test/audits.js
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import Promise from 'bluebird';
 
 chai.use(sinonChai);
 

--- a/test/exports.js
+++ b/test/exports.js
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import Promise from 'bluebird';
 
 chai.use(sinonChai);
 

--- a/test/safetyculture.js
+++ b/test/safetyculture.js
@@ -1,13 +1,9 @@
-import chai, { expect } from 'chai';
-import sinonChai from 'sinon-chai';
+import { expect } from 'chai';
 
-chai.use(sinonChai);
-
-import SafetyCulture from '../src/index';
+import { Client } from '../src/index';
 
 describe('SafetyCulture', () => {
   it('should export a Client', () => {
-    expect(SafetyCulture).to.exist;
-    expect(SafetyCulture.Client).to.exist;
+    expect(Client).to.exist;
   });
 });


### PR DESCRIPTION
- implement `npm run example:export`
- fix main export Babel6 issue
- add function to enable downloading export files
