### PR TITLE
Migrate tests to run within a docker container

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,10 @@
+# Note that the TARGET_ECS_SERVICE is required by the multistage docker script
+# This service is not actually a service, we just run the tests in a container
+env:
+  TARGET_ECS_SERVICE: safetyculture-js 
+
 steps:
-  - name: "Test"
-    command: "n lts && npm install && npm test"
+  - name: ":node: Run Tests"
+    command: "/etc/buildkite-agent/buildkite-scripts/ecs-npm-multistage-docker-build.sh -b"
     agents:
-      node: "true"
+      type: aws-builder

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*
+
+!.babelrc
+!.eslintrc
+!dist
+!examples
+!lib
+!package.json
+!src
+!test
+!webpack.config.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM safetyculture/node:8-builder AS builder8
+
+ENV HOME /home/safetyculture-js
+
+ARG NPM_TOKEN
+
+WORKDIR $HOME
+
+COPY [".babelrc", ".eslintrc", "package.json", "$HOME/"]
+
+RUN echo "--- :npm: Node 8 - Install Dependencies" && npm install
+
+COPY ["dist", "dist"]
+COPY ["lib", "lib"]
+COPY ["webpack.config.js", "webpack.config.js"]
+COPY ["examples", "examples"]
+COPY ["test", "test"]
+COPY ["src", "src"]
+
+RUN echo "--- :memo: Node 8 - Running Tests" && npm test


### PR DESCRIPTION
Migrating the tests to run in docker rather than run directly on our build agent. Note that the tests are now running against Node 8 rather than LTS.

Have verified that the tests run successfully here:
https://buildkite.com/safetyculture/safetyculture-js/builds/79#4fdf4eb8-92ad-40f1-bc99-df81c1d159c2
