### PR TITLE
BE-1394: Upgrade base docker image to be based on debian 9 image instead of debian 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM safetyculture/node:8-builder AS builder8
+FROM safetyculture/node:8-builder-stretch AS builder8
 
 ENV HOME /home/safetyculture-js
 


### PR DESCRIPTION
Upgrade docker base image to debian 9 as debian 8 EOL in June